### PR TITLE
Share ingress data source schema from ingress resource 

### DIFF
--- a/kubernetes/data_source_kubernetes_ingress.go
+++ b/kubernetes/data_source_kubernetes_ingress.go
@@ -6,98 +6,13 @@ import (
 )
 
 func dataSourceKubernetesIngress() *schema.Resource {
+	s := resourceKubernetesIngress().Schema
+	s["metadata"] = namespacedMetadataSchema("ingress", false)
+	s["spec"].Computed = true
+	s["spec"].Required = false
 	return &schema.Resource{
-		Read: dataSourceKubernetesIngressRead,
-
-		Schema: map[string]*schema.Schema{
-			"metadata": namespacedMetadataSchema("ingress", false),
-			"spec": {
-				Type:        schema.TypeList,
-				Description: "Spec defines the behavior of an ingress. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
-				MaxItems:    1,
-				Computed:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"backend": backendSpecFields(defaultBackendDescription),
-						"rule": {
-							Type:        schema.TypeList,
-							Description: "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.",
-							Optional:    true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"host": {
-										Type:        schema.TypeString,
-										Description: "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the IP in the Spec of the parent Ingress. 2. The : delimiter is not respected because ports are not allowed. Currently the port of an Ingress is implicitly :80 for http and :443 for https. Both these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
-										Optional:    true,
-									},
-									"http": {
-										Type:        schema.TypeList,
-										Required:    true,
-										MaxItems:    1,
-										Description: "http is a list of http selectors pointing to backends. In the example: http:///? -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"path": {
-													Type:        schema.TypeList,
-													Required:    true,
-													Description: "Path array of path regex associated with a backend. Incoming urls matching the path are forwarded to the backend.",
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"path": {
-																Type:        schema.TypeString,
-																Description: "path.regex is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.",
-																Optional:    true,
-															},
-															"backend": backendSpecFields(ruleBackedDescription),
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-						"tls": {
-							Type:        schema.TypeList,
-							Description: "TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.",
-							Optional:    true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"hosts": {
-										Type:        schema.TypeList,
-										Description: "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
-										Optional:    true,
-										Elem:        &schema.Schema{Type: schema.TypeString},
-									},
-									"secret_name": {
-										Type:        schema.TypeString,
-										Description: "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.",
-										Optional:    true,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			"load_balancer_ingress": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"ip": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"hostname": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-		},
+		Read:   dataSourceKubernetesIngressRead,
+		Schema: s,
 	}
 }
 


### PR DESCRIPTION
The ingress resource schema can be repurposed in the data source. The difference in the resource definition between `resource_kubernetes_ingress.go` and `data_source_kubernetes_ingress.go` is only a few.

```diff
13c8
< func resourceKubernetesIngress() *schema.Resource {
---
> func dataSourceKubernetesIngress() *schema.Resource {
15,22c10
< 		Create: resourceKubernetesIngressCreate,
< 		Read:   resourceKubernetesIngressRead,
< 		Exists: resourceKubernetesIngressExists,
< 		Update: resourceKubernetesIngressUpdate,
< 		Delete: resourceKubernetesIngressDelete,
< 		Importer: &schema.ResourceImporter{
< 			State: schema.ImportStatePassthrough,
< 		},
---
> 		Read: dataSourceKubernetesIngressRead,
25c13
< 			"metadata": namespacedMetadataSchema("ingress", true),
---
> 			"metadata": namespacedMetadataSchema("ingress", false),
29d16
< 				Required:    true,
30a18
> 				Computed:    true,
```